### PR TITLE
Setting rwsetV1ProtoBytes as binary with a local attribute file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,5 +9,3 @@
 *.js text eol=lf
 *.txt text eol=lf
 LICENSE text eol=lf
-# Define binary file attributes.
-rwsetV1ProtoBytes binary

--- a/core/ledger/kvledger/txmgmt/rwsetutil/.gitattributes
+++ b/core/ledger/kvledger/txmgmt/rwsetutil/.gitattributes
@@ -1,0 +1,2 @@
+# Define binary file attributes.
+rwsetV1ProtoBytes binary


### PR DESCRIPTION
Instead of modifying the .gitattributes located in the fabric
root directory, we add a new attribute file in the directory
where rwsetV1ProtoBytes is located.

<!-- Provide a general summary of your changes in the Title above -->

## Description
<!-- Describe your changes in detail. -->

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes #

## How Has This Been Tested?
<!-- If this PR does not contain a new test case, explain why. -->
<!-- Describe in detail how you tested your changes. -->

## Checklist:
<!-- To check a box, and an 'x': [x] -->
<!-- To uncheck box, add a space: [ ] -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- [] I have either added documentation to cover my changes or this change requires no new documentation.
- [] I have either added unit tests to cover my changes or this change requires no new tests.
- [] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

<!-- The continuous integration build process will run [make checks](https://github.com/hyperledger/fabric/blob/master/Makefile#L22) to confirm that tests pass and that code quality meets minimum standards. You may optionally run this locally as PRs will not be accepted until they pass. -->

Signed-off-by:
