### PR TITLE
privacy enable statemgmt

### DIFF
--- a/core/ledger/kvledger/txmgmt/privacyenabledstate/common_storage_db.go
+++ b/core/ledger/kvledger/txmgmt/privacyenabledstate/common_storage_db.go
@@ -1,0 +1,141 @@
+/*
+Copyright IBM Corp. 2016 All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+		 http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package privacyenabledstate
+
+import (
+	"encoding/base64"
+
+	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/statedb"
+	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/statedb/statecouchdb"
+	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/statedb/stateleveldb"
+	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/version"
+	"github.com/hyperledger/fabric/core/ledger/ledgerconfig"
+)
+
+const (
+	nsJoiner       = "/"
+	pvtDataPrefix  = "p"
+	hashDataPrefix = "h"
+)
+
+// CommonStorageDBProvider implements interface DBProvider
+type CommonStorageDBProvider struct {
+	statedb.VersionedDBProvider
+}
+
+// NewCommonStorageDBProvider constructs an instance of DBProvider
+func NewCommonStorageDBProvider() (DBProvider, error) {
+	var vdbProvider statedb.VersionedDBProvider
+	var err error
+	if !ledgerconfig.IsCouchDBEnabled() {
+		vdbProvider = stateleveldb.NewVersionedDBProvider()
+	} else {
+		if vdbProvider, err = statecouchdb.NewVersionedDBProvider(); err != nil {
+			return nil, err
+		}
+	}
+	return &CommonStorageDBProvider{vdbProvider}, nil
+}
+
+// GetDBHandle implements function from interface DBProvider
+func (p *CommonStorageDBProvider) GetDBHandle(id string) (DB, error) {
+	vdb, err := p.VersionedDBProvider.GetDBHandle(id)
+	if err != nil {
+		return nil, err
+	}
+	return NewCommonStorageDB(vdb, id)
+}
+
+// Close implements function from interface DBProvider
+func (p *CommonStorageDBProvider) Close() {
+	p.VersionedDBProvider.Close()
+}
+
+// CommonStorageDB implements interface DB. This implementation uses a single database to maintain
+// both the public and private data
+type CommonStorageDB struct {
+	statedb.VersionedDB
+}
+
+// NewCommonStorageDB wraps a VersionedDB instance. The public data is managed directly by the wrapped versionedDB.
+// For managing the hashed data and private data, this implementation creates separate namespaces in the wrapped db
+func NewCommonStorageDB(vdb statedb.VersionedDB, ledgerid string) (DB, error) {
+	return &CommonStorageDB{VersionedDB: vdb}, nil
+}
+
+// GetPrivateState implements corresponding function in interface PrivacyAwareVersionedDB
+func (s *CommonStorageDB) GetPrivateState(namespace, collection, key string) (*statedb.VersionedValue, error) {
+	return s.GetState(derivePvtDataNs(namespace, collection), key)
+}
+
+// GetValueHash implements corresponding function in interface PrivacyAwareVersionedDB
+func (s *CommonStorageDB) GetValueHash(namespace, collection string, keyHash []byte) (*statedb.VersionedValue, error) {
+	keyHashStr := string(keyHash)
+	if !s.BytesKeySuppoted() {
+		keyHashStr = base64.StdEncoding.EncodeToString(keyHash)
+	}
+	return s.GetState(deriveHashedDataNs(namespace, collection), keyHashStr)
+}
+
+// GetPrivateStateMultipleKeys implements corresponding function in interface PrivacyAwareVersionedDB
+func (s *CommonStorageDB) GetPrivateStateMultipleKeys(namespace, collection string, keys []string) ([]*statedb.VersionedValue, error) {
+	return s.GetStateMultipleKeys(derivePvtDataNs(namespace, collection), keys)
+}
+
+// GetPrivateStateRangeScanIterator implements corresponding function in interface PrivacyAwareVersionedDB
+func (s *CommonStorageDB) GetPrivateStateRangeScanIterator(namespace, collection, startKey, endKey string) (statedb.ResultsIterator, error) {
+	return s.GetStateRangeScanIterator(derivePvtDataNs(namespace, collection), startKey, endKey)
+}
+
+// ApplyPubPvtAndHashUpdates implements corresponding function in interface PrivacyAwareVersionedDB
+func (s *CommonStorageDB) ApplyPubPvtAndHashUpdates(
+	pubDataBatch *statedb.UpdateBatch, pvtDataBatch PvtDataBatch, hashedDataBatch PvtDataBatch, height *version.Height) error {
+	updateBatchWithPvtData(pubDataBatch, pvtDataBatch)
+	updateBatchWithHashedData(pubDataBatch, hashedDataBatch, !s.BytesKeySuppoted())
+	return s.ApplyUpdates(pubDataBatch, height)
+}
+
+func derivePvtDataNs(namespace, collection string) string {
+	return namespace + nsJoiner + pvtDataPrefix + collection
+}
+
+func deriveHashedDataNs(namespace, collection string) string {
+	return namespace + nsJoiner + hashDataPrefix + collection
+}
+
+func updateBatchWithPvtData(masterBatch *statedb.UpdateBatch, pvtDataBatch PvtDataBatch) {
+	for ns, nsBatch := range pvtDataBatch {
+		for _, coll := range nsBatch.GetCollectionNames() {
+			for key, vv := range nsBatch.GetUpdates(coll) {
+				masterBatch.Update(derivePvtDataNs(ns, coll), key, vv)
+			}
+		}
+	}
+}
+
+func updateBatchWithHashedData(masterBatch *statedb.UpdateBatch, pvtDataBatch PvtDataBatch, base64Key bool) {
+	for ns, nsBatch := range pvtDataBatch {
+		for _, coll := range nsBatch.GetCollectionNames() {
+			for key, vv := range nsBatch.GetUpdates(coll) {
+				if base64Key {
+					key = base64.StdEncoding.EncodeToString([]byte(key))
+				}
+				masterBatch.Update(deriveHashedDataNs(ns, coll), key, vv)
+			}
+		}
+	}
+}

--- a/core/ledger/kvledger/txmgmt/privacyenabledstate/db.go
+++ b/core/ledger/kvledger/txmgmt/privacyenabledstate/db.go
@@ -1,0 +1,84 @@
+/*
+Copyright IBM Corp. 2016 All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+		 http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package privacyenabledstate
+
+import (
+	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/statedb"
+	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/version"
+)
+
+// DBProvider provides handle to a PvtVersionedDB
+type DBProvider interface {
+	// GetDBHandle returns a handle to a PvtVersionedDB
+	GetDBHandle(id string) (DB, error)
+	// Close closes all the PvtVersionedDB instances and releases any resources held by VersionedDBProvider
+	Close()
+}
+
+// DB extends VersionedDB interface. This interface provides additional functions for managing private data state
+type DB interface {
+	statedb.VersionedDB
+	GetPrivateState(namespace, collection, key string) (*statedb.VersionedValue, error)
+	GetValueHash(namespace, collection string, keyHash []byte) (*statedb.VersionedValue, error)
+	GetPrivateStateMultipleKeys(namespace, collection string, keys []string) ([]*statedb.VersionedValue, error)
+	GetPrivateStateRangeScanIterator(namespace, collection, startKey, endKey string) (statedb.ResultsIterator, error)
+	ApplyPubPvtAndHashUpdates(pubDataBatch *statedb.UpdateBatch, pvtDataBatch PvtDataBatch, hashedDataBatch PvtDataBatch, height *version.Height) error
+}
+
+// PvtDataBatch contains either pvt data or hashes of the public data
+type PvtDataBatch map[string]nsBatch
+
+type nsBatch struct {
+	*statedb.UpdateBatch
+}
+
+// NewPvtDataBatch creates an empty PvtDataBatch
+func NewPvtDataBatch() PvtDataBatch {
+	return make(map[string]nsBatch)
+}
+
+// Put sets the value in the batch for a given combination of namespace and collection name
+func (b PvtDataBatch) Put(ns, coll, key string, value []byte, version *version.Height) {
+	b.getOrCreateNsBatch(ns).Put(coll, key, value, version)
+}
+
+// Delete removes the entry from the batch for a given combination of namespace and collection name
+func (b PvtDataBatch) Delete(ns, coll, key string, value []byte, version *version.Height) {
+	b.getOrCreateNsBatch(ns).Delete(coll, key, version)
+}
+
+// Get retrieves the value from the bacth for a given combination of namespace and collection name
+func (b PvtDataBatch) Get(ns, coll, key string) *statedb.VersionedValue {
+	nsPvtBatch, ok := b[ns]
+	if !ok {
+		return nil
+	}
+	return nsPvtBatch.Get(coll, key)
+}
+
+func (nsb nsBatch) GetCollectionNames() []string {
+	return nsb.GetUpdatedNamespaces()
+}
+
+func (b PvtDataBatch) getOrCreateNsBatch(ns string) nsBatch {
+	batch, ok := b[ns]
+	if !ok {
+		batch = nsBatch{statedb.NewUpdateBatch()}
+		b[ns] = batch
+	}
+	return batch
+}

--- a/core/ledger/kvledger/txmgmt/privacyenabledstate/db_test.go
+++ b/core/ledger/kvledger/txmgmt/privacyenabledstate/db_test.go
@@ -1,0 +1,47 @@
+package privacyenabledstate
+
+import (
+	"testing"
+
+	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/statedb"
+	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/version"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDB(t *testing.T) {
+	for _, env := range testEnvs {
+		t.Run(env.getName(), func(t *testing.T) {
+			testDB(t, env)
+		})
+	}
+}
+
+func testDB(t *testing.T, env testEnv) {
+	env.init(t)
+	defer env.cleanup()
+	db := env.getDBHandle("test-ledger-id")
+
+	pubDataBatch := statedb.NewUpdateBatch()
+	pubDataBatch.Put("ns1", "key1", []byte("value1"), version.NewHeight(1, 1))
+	pubDataBatch.Put("ns1", "key2", []byte("value2"), version.NewHeight(1, 2))
+	pubDataBatch.Put("ns2", "key3", []byte("value3"), version.NewHeight(1, 3))
+
+	pvtDataBatch := NewPvtDataBatch()
+	hashesBatch := NewPvtDataBatch()
+	populateBatches(t, pvtDataBatch, hashesBatch, "ns1", "coll1", "key1", []byte("pvt_value1"), version.NewHeight(1, 4))
+	populateBatches(t, pvtDataBatch, hashesBatch, "ns1", "coll1", "key2", []byte("pvt_value2"), version.NewHeight(1, 5))
+	populateBatches(t, pvtDataBatch, hashesBatch, "ns2", "coll1", "key3", []byte("pvt_value3"), version.NewHeight(1, 6))
+	db.ApplyPubPvtAndHashUpdates(pubDataBatch, pvtDataBatch, hashesBatch, version.NewHeight(2, 6))
+
+	vv, err := db.GetState("ns1", "key1")
+	assert.NoError(t, err)
+	assert.Equal(t, &statedb.VersionedValue{Value: []byte("value1"), Version: version.NewHeight(1, 1)}, vv)
+
+	vv, err = db.GetPrivateState("ns1", "coll1", "key1")
+	assert.NoError(t, err)
+	assert.Equal(t, &statedb.VersionedValue{Value: []byte("pvt_value1"), Version: version.NewHeight(1, 4)}, vv)
+
+	vv, err = db.GetValueHash("ns1", "coll1", testComputeStringHash(t, "key1"))
+	assert.NoError(t, err)
+	assert.Equal(t, &statedb.VersionedValue{Value: testComputeHash(t, []byte("pvt_value1")), Version: version.NewHeight(1, 4)}, vv)
+}

--- a/core/ledger/kvledger/txmgmt/privacyenabledstate/pkg_test.go
+++ b/core/ledger/kvledger/txmgmt/privacyenabledstate/pkg_test.go
@@ -1,0 +1,144 @@
+/*
+Copyright IBM Corp. 2016 All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+		 http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package privacyenabledstate
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/statedb/statecouchdb"
+	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/version"
+	"github.com/hyperledger/fabric/core/ledger/ledgerconfig"
+	"github.com/hyperledger/fabric/core/ledger/util"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	testFilesystemPath = "/tmp/fabric/ledgertests/kvledger/txmgmt/privacyenabledstate"
+)
+
+type testEnv interface {
+	init(t testing.TB)
+	getDBHandle(id string) DB
+	getName() string
+	cleanup()
+}
+
+// Tests will be run against each environment in this array
+// For example, to skip CouchDB tests, remove &couchDBLockBasedEnv{}
+var testEnvs = []testEnv{&levelDBCommonStorageTestEnv{}, &couchDBCommonStorageTestEnv{}}
+
+///////////// LevelDB Environment //////////////
+type levelDBCommonStorageTestEnv struct {
+	t        testing.TB
+	provider DBProvider
+}
+
+func (env *levelDBCommonStorageTestEnv) init(t testing.TB) {
+	viper.Set("peer.fileSystemPath", testFilesystemPath)
+	removeDBPath(t)
+	dbProvider, err := NewCommonStorageDBProvider()
+	assert.NoError(t, err)
+	env.t = t
+	env.provider = dbProvider
+}
+
+func (env *levelDBCommonStorageTestEnv) getDBHandle(id string) DB {
+	db, err := env.provider.GetDBHandle(id)
+	assert.NoError(env.t, err)
+	return db
+}
+
+func (env *levelDBCommonStorageTestEnv) getName() string {
+	return "levelDBCommonStorageTestEnv"
+}
+
+func (env *levelDBCommonStorageTestEnv) cleanup() {
+	env.provider.Close()
+	removeDBPath(env.t)
+}
+
+///////////// CouchDB Environment //////////////
+type couchDBCommonStorageTestEnv struct {
+	t         testing.TB
+	provider  DBProvider
+	openDbIds map[string]bool
+}
+
+func (env *couchDBCommonStorageTestEnv) init(t testing.TB) {
+	viper.Set("peer.fileSystemPath", testFilesystemPath)
+	viper.Set("ledger.state.stateDatabase", "CouchDB")
+	// both vagrant and CI have couchdb configured at host "couchdb"
+	viper.Set("ledger.state.couchDBConfig.couchDBAddress", "couchdb:5984")
+	// Replace with correct username/password such as
+	// admin/admin if user security is enabled on couchdb.
+	viper.Set("ledger.state.couchDBConfig.username", "")
+	viper.Set("ledger.state.couchDBConfig.password", "")
+	viper.Set("ledger.state.couchDBConfig.maxRetries", 3)
+	viper.Set("ledger.state.couchDBConfig.maxRetriesOnStartup", 10)
+	viper.Set("ledger.state.couchDBConfig.requestTimeout", time.Second*35)
+	dbProvider, err := NewCommonStorageDBProvider()
+	assert.NoError(t, err)
+	env.t = t
+	env.provider = dbProvider
+	env.openDbIds = make(map[string]bool)
+}
+
+func (env *couchDBCommonStorageTestEnv) getDBHandle(id string) DB {
+	db, err := env.provider.GetDBHandle(id)
+	assert.NoError(env.t, err)
+	env.openDbIds[id] = true
+	return db
+}
+
+func (env *couchDBCommonStorageTestEnv) getName() string {
+	return "couchDBCommonStorageTestEnv"
+}
+
+func (env *couchDBCommonStorageTestEnv) cleanup() {
+	for id := range env.openDbIds {
+		statecouchdb.CleanupDB(id)
+	}
+	env.provider.Close()
+}
+
+func removeDBPath(t testing.TB) {
+	dbPath := ledgerconfig.GetStateLevelDBPath()
+	if err := os.RemoveAll(dbPath); err != nil {
+		t.Fatalf("Err: %s", err)
+		t.FailNow()
+	}
+}
+
+func testComputeStringHash(t *testing.T, str string) []byte {
+	hash, err := util.ComputeStringHash(str)
+	assert.NoError(t, err)
+	return hash
+}
+
+func testComputeHash(t *testing.T, b []byte) []byte {
+	hash, err := util.ComputeHash(b)
+	assert.NoError(t, err)
+	return hash
+}
+
+func populateBatches(t *testing.T, pvtDataBatch PvtDataBatch, hashesBatch PvtDataBatch, ns, coll, key string, value []byte, ver *version.Height) {
+	pvtDataBatch.Put(ns, coll, key, value, ver)
+	hashesBatch.Put(ns, coll, string(testComputeStringHash(t, key)), testComputeHash(t, value), ver)
+}

--- a/core/ledger/kvledger/txmgmt/rwsetutil/rwset_proto_util.go
+++ b/core/ledger/kvledger/txmgmt/rwsetutil/rwset_proto_util.go
@@ -18,8 +18,8 @@ package rwsetutil
 
 import (
 	"github.com/golang/protobuf/proto"
-	bccspfactory "github.com/hyperledger/fabric/bccsp/factory"
 	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/version"
+	"github.com/hyperledger/fabric/core/ledger/util"
 	"github.com/hyperledger/fabric/protos/ledger/rwset"
 	"github.com/hyperledger/fabric/protos/ledger/rwset/kvrwset"
 )
@@ -279,7 +279,7 @@ func newKVWrite(key string, value []byte) *kvrwset.KVWrite {
 }
 
 func newPvtKVReadHash(key string, version *version.Height) (*kvrwset.KVReadHash, error) {
-	keyHash, err := computeKeyHash(key)
+	keyHash, err := util.ComputeStringHash(key)
 	if err != nil {
 		return nil, err
 	}
@@ -290,21 +290,13 @@ func newPvtKVWriteAndHash(key string, value []byte) (*kvrwset.KVWrite, *kvrwset.
 	kvWrite := newKVWrite(key, value)
 	var keyHash, valueHash []byte
 	var err error
-	if keyHash, err = computeKeyHash(key); err != nil {
+	if keyHash, err = util.ComputeStringHash(key); err != nil {
 		return nil, nil, err
 	}
 	if !kvWrite.IsDelete {
-		if valueHash, err = computeValueHash(value); err != nil {
+		if valueHash, err = util.ComputeHash(value); err != nil {
 			return nil, nil, err
 		}
 	}
 	return kvWrite, &kvrwset.KVWriteHash{KeyHash: keyHash, IsDelete: kvWrite.IsDelete, ValueHash: valueHash}, nil
-}
-
-func computeKeyHash(input string) ([]byte, error) {
-	return computeValueHash([]byte(input))
-}
-
-func computeValueHash(input []byte) ([]byte, error) {
-	return bccspfactory.GetDefault().Hash([]byte(input), hashOpts)
 }

--- a/core/ledger/kvledger/txmgmt/statedb/statecouchdb/statecouchdb.go
+++ b/core/ledger/kvledger/txmgmt/statedb/statecouchdb/statecouchdb.go
@@ -122,6 +122,11 @@ func (vdb *VersionedDB) ValidateKey(key string) error {
 	return nil
 }
 
+// BytesKeySuppoted implements method in VersionedDB interface
+func (vdb *VersionedDB) BytesKeySuppoted() bool {
+	return false
+}
+
 // GetState implements method in VersionedDB interface
 func (vdb *VersionedDB) GetState(namespace string, key string) (*statedb.VersionedValue, error) {
 	logger.Debugf("GetState(). ns=%s, key=%s", namespace, key)

--- a/core/ledger/kvledger/txmgmt/statedb/statecouchdb/statecouchdb_test_export.go
+++ b/core/ledger/kvledger/txmgmt/statedb/statecouchdb/statecouchdb_test_export.go
@@ -43,16 +43,17 @@ func NewTestVDBEnv(t testing.TB) *TestVDBEnv {
 // Cleanup drops the test couch databases and closes the db provider
 func (env *TestVDBEnv) Cleanup(dbName string) {
 	env.t.Logf("Cleaningup TestVDBEnv")
-	cleanupDB(strings.ToLower(dbName))
 	env.DBProvider.Close()
 
 }
-func cleanupDB(dbName string) {
+
+// CleanupDB drops the test couch databases
+func CleanupDB(dbName string) {
 	//create a new connection
 	couchDBDef := couchdb.GetCouchDBDefinition()
 	couchInstance, _ := couchdb.CreateCouchInstance(couchDBDef.URL, couchDBDef.Username, couchDBDef.Password,
 		couchDBDef.MaxRetries, couchDBDef.MaxRetriesOnStartup, couchDBDef.RequestTimeout)
-	db := couchdb.CouchDatabase{CouchInstance: *couchInstance, DBName: dbName}
+	db := couchdb.CouchDatabase{CouchInstance: *couchInstance, DBName: strings.ToLower(dbName)}
 	//drop the test database
 	db.DropDatabase()
 }

--- a/core/ledger/kvledger/txmgmt/statedb/stateleveldb/stateleveldb.go
+++ b/core/ledger/kvledger/txmgmt/statedb/stateleveldb/stateleveldb.go
@@ -84,6 +84,11 @@ func (vdb *versionedDB) ValidateKey(key string) error {
 	return nil
 }
 
+// BytesKeySuppoted implements method in VersionedDB interface
+func (vdb *versionedDB) BytesKeySuppoted() bool {
+	return true
+}
+
 // GetState implements method in VersionedDB interface
 func (vdb *versionedDB) GetState(namespace string, key string) (*statedb.VersionedValue, error) {
 	logger.Debugf("GetState(). ns=%s, key=%s", namespace, key)

--- a/core/ledger/util/util.go
+++ b/core/ledger/util/util.go
@@ -19,6 +19,13 @@ package util
 import (
 	"reflect"
 	"sort"
+
+	"github.com/hyperledger/fabric/bccsp"
+	bccspfactory "github.com/hyperledger/fabric/bccsp/factory"
+)
+
+var (
+	hashOpts = &bccsp.SHA256Opts{}
 )
 
 // GetSortedKeys returns the keys of the map in a sorted order. This function assumes that the keys are string
@@ -75,4 +82,14 @@ func (keys keys) Swap(i, j int) {
 
 func (keys keys) Less(i, j int) bool {
 	return keys[i].str < keys[j].str
+}
+
+// ComputeStringHash computes the hash of the given string
+func ComputeStringHash(input string) ([]byte, error) {
+	return ComputeHash([]byte(input))
+}
+
+// ComputeHash computes the hash of the given bytes
+func ComputeHash(input []byte) ([]byte, error) {
+	return bccspfactory.GetDefault().Hash([]byte(input), hashOpts)
 }


### PR DESCRIPTION
Change-Id: Iac935dfe1744a526401b9d449f1ba81eecefc54d

Changes for state management.
- Introduced an interface for maintaining  privacy enabled state
- An implementation of the above interface that maintains the public data, the private data, and the hashes into a single logical underlying db
- Unit tests at the level of interface. Other future impls of the interface need not rewrite the existing tests again

## Description
<!-- Describe your changes in detail. -->

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes #

## How Has This Been Tested?
<!-- If this PR does not contain a new test case, explain why. -->
<!-- Describe in detail how you tested your changes. -->

## Checklist:
<!-- To check a box, and an 'x': [x] -->
<!-- To uncheck box, add a space: [ ] -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- [] I have either added documentation to cover my changes or this change requires no new documentation.
- [] I have either added unit tests to cover my changes or this change requires no new tests.
- [] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

<!-- The continuous integration build process will run [make checks](https://github.com/hyperledger/fabric/blob/master/Makefile#L22) to confirm that tests pass and that code quality meets minimum standards. You may optionally run this locally as PRs will not be accepted until they pass. -->

Signed-off-by:
