### PR TITLE
Persisting pvt writeset into transient store

### DIFF
--- a/core/ledger/kvledger/kv_ledger.go
+++ b/core/ledger/kvledger/kv_ledger.go
@@ -28,7 +28,7 @@ import (
 	"github.com/hyperledger/fabric/core/ledger/kvledger/history/historydb"
 	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/privacyenabledstate"
 	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/txmgr"
-	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/txmgr/lockbasedtxmgr"
+	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/txmgr/transienthandlertxmgr"
 	"github.com/hyperledger/fabric/core/ledger/ledgerconfig"
 	"github.com/hyperledger/fabric/core/ledger/pvtrwstorage"
 	"github.com/hyperledger/fabric/protos/common"
@@ -56,7 +56,7 @@ func newKVLedger(ledgerID string, blockStore blkstorage.BlockStore,
 
 	//Initialize transaction manager using state database
 	var txmgmt txmgr.TxMgr
-	txmgmt = lockbasedtxmgr.NewLockBasedTxMgr(versionedDB)
+	txmgmt = transienthandlertxmgr.NewLockbasedTxMgr(versionedDB, transientStore)
 
 	// Create a kvLedger for this chain/ledger, which encasulates the underlying
 	// id store, blockstore, txmgr (state database), history database

--- a/core/ledger/kvledger/txmgmt/privacyenabledstate/test_exports.go
+++ b/core/ledger/kvledger/txmgmt/privacyenabledstate/test_exports.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// TestEnv - an interface that a test environment implements
 type TestEnv interface {
 	Init(t testing.TB)
 	GetDBHandle(id string) DB
@@ -40,11 +41,14 @@ type TestEnv interface {
 var testEnvs = []TestEnv{&LevelDBCommonStorageTestEnv{}, &CouchDBCommonStorageTestEnv{}}
 
 ///////////// LevelDB Environment //////////////
+
+// LevelDBCommonStorageTestEnv implements TestEnv interface for leveldb based storage
 type LevelDBCommonStorageTestEnv struct {
 	t        testing.TB
 	provider DBProvider
 }
 
+// Init implements corresponding function from interface TestEnv
 func (env *LevelDBCommonStorageTestEnv) Init(t testing.TB) {
 	viper.Set("ledger.state.stateDatabase", "")
 	removeDBPath(t)
@@ -54,28 +58,34 @@ func (env *LevelDBCommonStorageTestEnv) Init(t testing.TB) {
 	env.provider = dbProvider
 }
 
+// GetDBHandle implements corresponding function from interface TestEnv
 func (env *LevelDBCommonStorageTestEnv) GetDBHandle(id string) DB {
 	db, err := env.provider.GetDBHandle(id)
 	assert.NoError(env.t, err)
 	return db
 }
 
+// GetName implements corresponding function from interface TestEnv
 func (env *LevelDBCommonStorageTestEnv) GetName() string {
 	return "levelDBCommonStorageTestEnv"
 }
 
+// Cleanup implements corresponding function from interface TestEnv
 func (env *LevelDBCommonStorageTestEnv) Cleanup() {
 	env.provider.Close()
 	removeDBPath(env.t)
 }
 
 ///////////// CouchDB Environment //////////////
+
+// CouchDBCommonStorageTestEnv implements TestEnv interface for couchdb based storage
 type CouchDBCommonStorageTestEnv struct {
 	t         testing.TB
 	provider  DBProvider
 	openDbIds map[string]bool
 }
 
+// Init implements corresponding function from interface TestEnv
 func (env *CouchDBCommonStorageTestEnv) Init(t testing.TB) {
 	viper.Set("ledger.state.stateDatabase", "CouchDB")
 	// both vagrant and CI have couchdb configured at host "couchdb"
@@ -94,6 +104,7 @@ func (env *CouchDBCommonStorageTestEnv) Init(t testing.TB) {
 	env.openDbIds = make(map[string]bool)
 }
 
+// GetDBHandle implements corresponding function from interface TestEnv
 func (env *CouchDBCommonStorageTestEnv) GetDBHandle(id string) DB {
 	db, err := env.provider.GetDBHandle(id)
 	assert.NoError(env.t, err)
@@ -101,10 +112,12 @@ func (env *CouchDBCommonStorageTestEnv) GetDBHandle(id string) DB {
 	return db
 }
 
+// GetName implements corresponding function from interface TestEnv
 func (env *CouchDBCommonStorageTestEnv) GetName() string {
 	return "couchDBCommonStorageTestEnv"
 }
 
+// Cleanup implements corresponding function from interface TestEnv
 func (env *CouchDBCommonStorageTestEnv) Cleanup() {
 	for id := range env.openDbIds {
 		statecouchdb.CleanupDB(id)

--- a/core/ledger/kvledger/txmgmt/txmgr/lockbasedtxmgr/lockbased_tx_simulator.go
+++ b/core/ledger/kvledger/txmgmt/txmgr/lockbasedtxmgr/lockbased_tx_simulator.go
@@ -26,23 +26,14 @@ import (
 // LockBasedTxSimulator is a transaction simulator used in `LockBasedTxMgr`
 type lockBasedTxSimulator struct {
 	lockBasedQueryExecutor
-	rwsetBuilder    *rwsetutil.RWSetBuilder
-	simulationBlkHt uint64
+	rwsetBuilder *rwsetutil.RWSetBuilder
 }
 
 func newLockBasedTxSimulator(txmgr *LockBasedTxMgr, txid string) (*lockBasedTxSimulator, error) {
 	rwsetBuilder := rwsetutil.NewRWSetBuilder()
 	helper := &queryHelper{txmgr: txmgr, rwsetBuilder: rwsetBuilder}
 	logger.Debugf("constructing new tx simulator txid = [%s]", txid)
-	ver, err := txmgr.GetLastSavepoint()
-	if err != nil {
-		return nil, err
-	}
-	simulationBlkHt := uint64(0)
-	if ver != nil {
-		simulationBlkHt = ver.BlockNum
-	}
-	return &lockBasedTxSimulator{lockBasedQueryExecutor{helper, txid}, rwsetBuilder, simulationBlkHt}, nil
+	return &lockBasedTxSimulator{lockBasedQueryExecutor{helper, txid}, rwsetBuilder}, nil
 }
 
 // GetState implements method in interface `ledger.TxSimulator`

--- a/core/ledger/kvledger/txmgmt/txmgr/transienthandlertxmgr/transient_handler_txmgr.go
+++ b/core/ledger/kvledger/txmgmt/txmgr/transienthandlertxmgr/transient_handler_txmgr.go
@@ -1,0 +1,95 @@
+/*
+Copyright IBM Corp. 2016 All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+		 http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package transienthandlertxmgr
+
+import (
+	"github.com/hyperledger/fabric/common/flogging"
+	"github.com/hyperledger/fabric/core/ledger"
+	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/privacyenabledstate"
+	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/txmgr"
+	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/txmgr/lockbasedtxmgr"
+	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/version"
+	"github.com/hyperledger/fabric/core/ledger/pvtrwstorage"
+)
+
+var logger = flogging.MustGetLogger("transienthandlertxmgr")
+
+// TransisentHandlerTxMgr wraps a specific txmgr implementation (such as lockbasedtxmgr)
+// and adds the additional functionality of persisting the private writesets into transient store
+type TransisentHandlerTxMgr struct {
+	txmgr.TxMgr
+	tStore pvtrwstorage.TransientStore
+}
+
+// NewLockbasedTxMgr constructs a new instance of TransisentHandlerTxMgr
+func NewLockbasedTxMgr(db privacyenabledstate.DB, tStore pvtrwstorage.TransientStore) *TransisentHandlerTxMgr {
+	return &TransisentHandlerTxMgr{lockbasedtxmgr.NewLockBasedTxMgr(db), tStore}
+}
+
+// NewTxSimulator extends the implementation of this function in the wrapped txmgr.
+func (w *TransisentHandlerTxMgr) NewTxSimulator(txid string) (ledger.TxSimulator, error) {
+	var ht *version.Height
+	var err error
+	var actualTxSim ledger.TxSimulator
+	var simBlkHt uint64
+
+	if ht, err = w.TxMgr.GetLastSavepoint(); err != nil {
+		return nil, err
+	}
+
+	if ht != nil {
+		simBlkHt = ht.BlockNum
+	}
+
+	if actualTxSim, err = w.TxMgr.NewTxSimulator(txid); err != nil {
+		return nil, err
+	}
+	return newSimulatorWrapper(actualTxSim, w.tStore, txid, simBlkHt), nil
+}
+
+// transisentHandlerTxSimulator wraps a txsimulator and adds the additional functionality of persisting
+// the private writesets into transient store
+type transisentHandlerTxSimulator struct {
+	ledger.TxSimulator
+	tStore   pvtrwstorage.TransientStore
+	txid     string
+	simBlkHt uint64
+}
+
+func newSimulatorWrapper(actualSim ledger.TxSimulator, tStore pvtrwstorage.TransientStore, txid string, simBlkHt uint64) *transisentHandlerTxSimulator {
+	return &transisentHandlerTxSimulator{actualSim, tStore, txid, simBlkHt}
+}
+
+func (w *transisentHandlerTxSimulator) GetTxSimulationResults() (*ledger.TxSimulationResults, error) {
+	var txSimRes *ledger.TxSimulationResults
+	var pvtSimBytes []byte
+	var err error
+
+	if txSimRes, err = w.TxSimulator.GetTxSimulationResults(); err != nil || !txSimRes.ContainsPvtWrites() {
+		logger.Debugf("Not adding private simulation results into transient store for txid=[%s]. Results available=%t, err=%#v",
+			w.txid, txSimRes.ContainsPvtWrites(), err)
+		return txSimRes, err
+	}
+	if pvtSimBytes, err = txSimRes.GetPvtSimulationBytes(); err != nil {
+		return nil, err
+	}
+	logger.Debugf("Adding private simulation results into transient store for txid = [%s]", w.txid)
+	if err = w.tStore.Persist(w.txid, "", w.simBlkHt, pvtSimBytes); err != nil {
+		return nil, err
+	}
+	return txSimRes, nil
+}

--- a/core/ledger/kvledger/txmgmt/txmgr/transienthandlertxmgr/transient_handler_txmgr_test.go
+++ b/core/ledger/kvledger/txmgmt/txmgr/transienthandlertxmgr/transient_handler_txmgr_test.go
@@ -1,0 +1,114 @@
+/*
+Copyright IBM Corp. 2016 All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+		 http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package transienthandlertxmgr
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hyperledger/fabric/common/flogging"
+	"github.com/hyperledger/fabric/core/ledger"
+	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/privacyenabledstate"
+	"github.com/hyperledger/fabric/core/ledger/pvtrwstorage"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	dbTestEnvs = []privacyenabledstate.TestEnv{
+		&privacyenabledstate.LevelDBCommonStorageTestEnv{},
+		&privacyenabledstate.CouchDBCommonStorageTestEnv{},
+	}
+)
+
+func TestMain(m *testing.M) {
+	flogging.SetModuleLevel("transienthandlertxmgr", "debug")
+	viper.Set("peer.fileSystemPath", "/tmp/fabric/ledgertests/kvledger/txmgmt/txmgr/transienthandlertxmgr")
+	os.Exit(m.Run())
+}
+
+func TestTransientHandlerTxmgr(t *testing.T) {
+	for _, dbEnv := range dbTestEnvs {
+		dbEnv.Init(t)
+		defer dbEnv.Cleanup()
+		tStoreTestEnv := pvtrwstorage.NewTestTransientStoreEnv(t)
+		defer tStoreTestEnv.Cleanup()
+		testTransientHandlerTxmgr(t, dbEnv.GetName(), dbEnv.GetDBHandle("test"), tStoreTestEnv.TestTransientStore)
+	}
+}
+
+func testTransientHandlerTxmgr(t *testing.T, testcase string, db privacyenabledstate.DB, tStore pvtrwstorage.TransientStore) {
+	t.Run(testcase, func(t *testing.T) {
+		// initially the transient store is empty
+		txid := "test-tx-id"
+		initialEntries := retrieveTestEntriesFromTStore(t, tStore, txid)
+		t.Logf("len(initialEntries)=%d", len(initialEntries))
+		assert.Nil(t, initialEntries)
+		txmgr := NewLockbasedTxMgr(db, tStore)
+
+		// run a simulation with only public data and the transient store should be empty at the end
+		sim1, err := txmgr.NewTxSimulator(txid)
+		assert.NoError(t, err)
+		sim1.GetState("ns1", "key1")
+		sim1.SetState("ns1", "key1", []byte("value1"))
+		_, err = sim1.GetTxSimulationResults()
+		assert.NoError(t, err)
+		entriesAfterPubSimulation := retrieveTestEntriesFromTStore(t, tStore, txid)
+		assert.Nil(t, entriesAfterPubSimulation)
+
+		// run a read-only private simulation and the transient store should be empty at the end
+		sim2, err := txmgr.NewTxSimulator(txid)
+		assert.NoError(t, err)
+		sim2.GetState("ns1", "key1")
+		sim2.SetState("ns1", "key1", []byte("value1"))
+		sim2.GetPrivateData("ns1", "key1", "coll1")
+		_, err = sim2.GetTxSimulationResults()
+		assert.NoError(t, err)
+		entriesAfterReadOnlyPvtSimulation := retrieveTestEntriesFromTStore(t, tStore, txid)
+		assert.Nil(t, entriesAfterReadOnlyPvtSimulation)
+
+		// run a private simulation that inlovles writes and the transient store should have a corresponding entry at the end
+		sim3, err := txmgr.NewTxSimulator(txid)
+		assert.NoError(t, err)
+		sim3.GetState("ns1", "key1")
+		sim3.SetState("ns1", "key1", []byte("value1"))
+		sim3.GetPrivateData("ns1", "key1", "coll1")
+		sim3.SetPrivateData("ns1", "key1", "coll1", []byte("value1"))
+		sim3Res, err := sim3.GetTxSimulationResults()
+		assert.NoError(t, err)
+		sim3ResBytes, err := sim3Res.GetPvtSimulationBytes()
+		assert.NoError(t, err)
+		entriesAfterWritePvtSimulation := retrieveTestEntriesFromTStore(t, tStore, txid)
+		assert.Equal(t, 1, len(entriesAfterWritePvtSimulation))
+		assert.Equal(t, sim3ResBytes, entriesAfterWritePvtSimulation[0].PrivateSimulationResults)
+	})
+}
+
+func retrieveTestEntriesFromTStore(t *testing.T, tStore pvtrwstorage.TransientStore, txid string) []*ledger.EndorserPrivateSimulationResults {
+	itr, err := tStore.GetTxPrivateRWSetByTxid(txid)
+	assert.NoError(t, err)
+	var results []*ledger.EndorserPrivateSimulationResults
+	for {
+		result, err := itr.Next()
+		assert.NoError(t, err)
+		if result == nil {
+			break
+		}
+		results = append(results, result.(*ledger.EndorserPrivateSimulationResults))
+	}
+	return results
+}

--- a/core/ledger/ledger_interface.go
+++ b/core/ledger/ledger_interface.go
@@ -198,5 +198,13 @@ func (txSim *TxSimulationResults) GetPubSimulationBytes() ([]byte, error) {
 
 // GetPvtSimulationBytes returns the serialized bytes of private readwrite set
 func (txSim *TxSimulationResults) GetPvtSimulationBytes() ([]byte, error) {
+	if !txSim.ContainsPvtWrites() {
+		return nil, nil
+	}
 	return proto.Marshal(txSim.PvtSimulationResults)
+}
+
+// ContainsPvtWrites returns true if the simulation results include the private writes
+func (txSim *TxSimulationResults) ContainsPvtWrites() bool {
+	return txSim.PvtSimulationResults != nil
 }

--- a/core/ledger/pvtrwstorage/test_exports.go
+++ b/core/ledger/pvtrwstorage/test_exports.go
@@ -24,22 +24,25 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-type transientStoreEnv struct {
+// TransientStoreEnv provides the transient store env for testing
+type TransientStoreEnv struct {
 	t                          testing.TB
 	testTransientStoreProvider TransientStoreProvider
-	testTransientStore         TransientStore
+	TestTransientStore         TransientStore
 }
 
-func newTestTransientStoreEnv(t *testing.T) *transientStoreEnv {
+// NewTestTransientStoreEnv construct a TransientStoreEnv for testing
+func NewTestTransientStoreEnv(t *testing.T) *TransientStoreEnv {
 	removeTransientStorePath(t)
 	assert := assert.New(t)
 	testTransientStoreProvider := NewTransientStoreProvider()
 	testTransientStore, err := testTransientStoreProvider.OpenStore("TestTransientStore")
 	assert.NoError(err)
-	return &transientStoreEnv{t, testTransientStoreProvider, testTransientStore}
+	return &TransientStoreEnv{t, testTransientStoreProvider, testTransientStore}
 }
 
-func (env *transientStoreEnv) cleanup() {
+// Cleanup cleansup the transient store env after testing
+func (env *TransientStoreEnv) Cleanup() {
 	env.testTransientStoreProvider.Close()
 	removeTransientStorePath(env.t)
 }

--- a/core/ledger/pvtrwstorage/transient_store_test.go
+++ b/core/ledger/pvtrwstorage/transient_store_test.go
@@ -76,7 +76,7 @@ func TestRWSetKeyCodingEncoding(t *testing.T) {
 }
 
 func TestTransientStorePersistAndRetrieve(t *testing.T) {
-	env := newTestTransientStoreEnv(t)
+	env := NewTestTransientStoreEnv(t)
 	assert := assert.New(t)
 	txid := "txid-1"
 
@@ -102,14 +102,14 @@ func TestTransientStorePersistAndRetrieve(t *testing.T) {
 	// Persist simulation results into transient store
 	var err error
 	for i := 0; i < len(endorsersResults); i++ {
-		err = env.testTransientStore.Persist(txid, endorsersResults[i].EndorserID,
+		err = env.TestTransientStore.Persist(txid, endorsersResults[i].EndorserID,
 			endorsersResults[i].EndorsementBlockHeight, endorsersResults[i].PrivateSimulationResults)
 		assert.NoError(err)
 	}
 
 	// Retrieve simulation results of txid-1 from transient store
 	var iter commonledger.ResultsIterator
-	iter, err = env.testTransientStore.GetTxPrivateRWSetByTxid(txid)
+	iter, err = env.TestTransientStore.GetTxPrivateRWSetByTxid(txid)
 	assert.NoError(err)
 
 	var result commonledger.QueryResult
@@ -127,7 +127,7 @@ func TestTransientStorePersistAndRetrieve(t *testing.T) {
 }
 
 func TestTransientStorePurge(t *testing.T) {
-	env := newTestTransientStoreEnv(t)
+	env := NewTestTransientStoreEnv(t)
 	assert := assert.New(t)
 
 	txid := "txid-1"
@@ -178,19 +178,19 @@ func TestTransientStorePurge(t *testing.T) {
 	// Persist simulation results into transient store
 	var err error
 	for i := 0; i < 5; i++ {
-		err = env.testTransientStore.Persist(txid, endorsersResults[i].EndorserID,
+		err = env.TestTransientStore.Persist(txid, endorsersResults[i].EndorserID,
 			endorsersResults[i].EndorsementBlockHeight, endorsersResults[i].PrivateSimulationResults)
 		assert.NoError(err)
 	}
 
 	// Retain results generate at block height greater than or equal to 12
 	minEndorsementBlkHtToRetain := uint64(12)
-	err = env.testTransientStore.Purge(minEndorsementBlkHtToRetain)
+	err = env.TestTransientStore.Purge(minEndorsementBlkHtToRetain)
 	assert.NoError(err)
 
 	// Retrieve simulation results of txid-1 from transient store
 	var iter commonledger.ResultsIterator
-	iter, err = env.testTransientStore.GetTxPrivateRWSetByTxid(txid)
+	iter, err = env.TestTransientStore.GetTxPrivateRWSetByTxid(txid)
 	assert.NoError(err)
 
 	// Expected results for txid-1
@@ -215,24 +215,24 @@ func TestTransientStorePurge(t *testing.T) {
 
 	// Get the minimum retained endorsement block height
 	var actualMinEndorsementBlkHt uint64
-	actualMinEndorsementBlkHt, err = env.testTransientStore.GetMinEndorsementBlkHt()
+	actualMinEndorsementBlkHt, err = env.TestTransientStore.GetMinEndorsementBlkHt()
 	assert.NoError(err)
 	assert.Equal(minEndorsementBlkHtToRetain, actualMinEndorsementBlkHt)
 
 	// Retain results generate at block height greater than or equal to 15
 	minEndorsementBlkHtToRetain = uint64(15)
-	err = env.testTransientStore.Purge(minEndorsementBlkHtToRetain)
+	err = env.TestTransientStore.Purge(minEndorsementBlkHtToRetain)
 	assert.NoError(err)
 
 	// There should be no entries in the transient store
-	actualMinEndorsementBlkHt, err = env.testTransientStore.GetMinEndorsementBlkHt()
+	actualMinEndorsementBlkHt, err = env.TestTransientStore.GetMinEndorsementBlkHt()
 	assert.Equal(err, ErrTransientStoreEmpty)
 
 	// Retain results generate at block height greater than or equal to 15
 	minEndorsementBlkHtToRetain = uint64(15)
-	err = env.testTransientStore.Purge(minEndorsementBlkHtToRetain)
+	err = env.TestTransientStore.Purge(minEndorsementBlkHtToRetain)
 	// Should not return any error
 	assert.NoError(err)
 
-	env.cleanup()
+	env.Cleanup()
 }


### PR DESCRIPTION
Added a txmgr 'TransisentHandlerTxMgr' which wraps the actual txmgr and adds
functionality on top for persisting the private simulation results into
transient store

Change-Id: I555dc6c91f76e92cb2768cb57188c6403fadd74a

<!-- Provide a general summary of your changes in the Title above -->

## Description
<!-- Describe your changes in detail. -->

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes #

## How Has This Been Tested?
<!-- If this PR does not contain a new test case, explain why. -->
<!-- Describe in detail how you tested your changes. -->

## Checklist:
<!-- To check a box, and an 'x': [x] -->
<!-- To uncheck box, add a space: [ ] -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- [] I have either added documentation to cover my changes or this change requires no new documentation.
- [] I have either added unit tests to cover my changes or this change requires no new tests.
- [] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

<!-- The continuous integration build process will run [make checks](https://github.com/hyperledger/fabric/blob/master/Makefile#L22) to confirm that tests pass and that code quality meets minimum standards. You may optionally run this locally as PRs will not be accepted until they pass. -->

Signed-off-by:
