### PR TITLE
Fix for read-only pvt data tx

### DIFF
--- a/core/ledger/kvledger/txmgmt/validator/statebasedval/state_based_validator.go
+++ b/core/ledger/kvledger/txmgmt/validator/statebasedval/state_based_validator.go
@@ -221,8 +221,10 @@ func (v *Validator) validateKVReadHash(ns, coll string, kvReadHash *kvrwset.KVRe
 	if err != nil {
 		return false, err
 	}
-	committedVersion := versionedHash.Version
-
+	var committedVersion *version.Height
+	if versionedHash != nil {
+		committedVersion = versionedHash.Version
+	}
 	if !version.AreSame(committedVersion, rwsetutil.NewVersion(kvReadHash.Version)) {
 		logger.Debugf("Version mismatch for key hash [%s:%s:%#v]. Committed version = [%s], Version in hashedReadSet [%s]",
 			ns, coll, kvReadHash.KeyHash, committedVersion, kvReadHash.Version)

--- a/core/ledger/kvledger/txmgmt/validator/valimpl/default_impl.go
+++ b/core/ledger/kvledger/txmgmt/validator/valimpl/default_impl.go
@@ -89,7 +89,7 @@ func (impl *DefaultImpl) validatePvtWriteSet(block *valinternal.Block) (*privacy
 		if tx.ValidationCode != peer.TxValidationCode_VALID {
 			continue
 		}
-		if !tx.InvolvesPvtData() {
+		if !tx.ContainsPvtWrites() {
 			continue
 		}
 		var pvtSimRes *ledger.EndorserPrivateSimulationResults

--- a/core/ledger/kvledger/txmgmt/validator/valinternal/val_internal.go
+++ b/core/ledger/kvledger/txmgmt/validator/valinternal/val_internal.go
@@ -60,11 +60,13 @@ func NewPubAndHashUpdates() *PubAndHashUpdates {
 	}
 }
 
-// InvolvesPvtData returns true if this transaction is not limited to affecting the public data only
-func (t *Transaction) InvolvesPvtData() bool {
+// ContainsPvtWrites returns true if this transaction is not limited to affecting the public data only
+func (t *Transaction) ContainsPvtWrites() bool {
 	for _, ns := range t.RWSet.NsRwSets {
-		if len(ns.CollHashedRwSets) > 0 {
-			return true
+		for _, coll := range ns.CollHashedRwSets {
+			if coll.PvtRwSetHash != nil {
+				return true
+			}
 		}
 	}
 	return false


### PR DESCRIPTION
Change-Id: Ibf7b2f79f7b535c78eeaae5ecece12874bf20f5f

<!-- Provide a general summary of your changes in the Title above -->

## Description
<!-- Describe your changes in detail. -->

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes #

## How Has This Been Tested?
<!-- If this PR does not contain a new test case, explain why. -->
<!-- Describe in detail how you tested your changes. -->

## Checklist:
<!-- To check a box, and an 'x': [x] -->
<!-- To uncheck box, add a space: [ ] -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- [] I have either added documentation to cover my changes or this change requires no new documentation.
- [] I have either added unit tests to cover my changes or this change requires no new tests.
- [] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

<!-- The continuous integration build process will run [make checks](https://github.com/hyperledger/fabric/blob/master/Makefile#L22) to confirm that tests pass and that code quality meets minimum standards. You may optionally run this locally as PRs will not be accepted until they pass. -->

Signed-off-by:
